### PR TITLE
Add GitHub Actions workflow for CI/CD pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,16 +16,16 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: Set up Node.js
-      uses: actions/setup-node@v2
+    - name: Set up JDK
+      uses: actions/setup-java@v2
       with:
-        node-version: '16'
+        java-version: '11'
 
-    - name: Install dependencies
-      run: npm install
+    - name: Build with Maven
+      run: mvn clean install
 
     - name: Run tests
-      run: npm test
+      run: mvn test
 
   deploy:
     needs: build

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,36 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '16'
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Run tests
+      run: npm test
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Deploy application
+      run: echo "Deploying application..."


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow for CI/CD pipeline. The workflow includes:

- **Build Job**:
  - Checkout code
  - Set up JDK
  - Build with Maven
  - Run tests

- **Deploy Job**:
  - Deploy application after successful build

The workflow triggers on push and pull requests to the `main` branch.